### PR TITLE
refactor: change deserialization to prioritize most recent

### DIFF
--- a/src/persistence/deserialization/deserialization-manager.test.ts
+++ b/src/persistence/deserialization/deserialization-manager.test.ts
@@ -29,7 +29,7 @@ describe('Deserialization manager', () => {
     expect(deserializer.deserialize).toHaveBeenCalledTimes(1);
   });
 
-  test('uses first matching deserializer', () => {
+  test('uses most recently registered matching deserializer', () => {
     const firstDeserializer = createDeserializerMatchingNumber(5);
     const secondDeserializer = createDeserializerMatchingNumber(6);
     const thirdDeserializer = createDeserializerMatchingNumber(6);
@@ -41,9 +41,9 @@ describe('Deserialization manager', () => {
 
     expect(firstDeserializer.deserialize).not.toHaveBeenCalled();
 
-    expect(secondDeserializer.deserialize).toHaveBeenCalledTimes(1);
+    expect(thirdDeserializer.deserialize).toHaveBeenCalledTimes(1);
 
-    expect(thirdDeserializer.deserialize).not.toHaveBeenCalled();
+    expect(secondDeserializer.deserialize).not.toHaveBeenCalled();
   });
 
   test('throws error if no matching deserializer found', () => {

--- a/src/persistence/deserialization/deserialization-manager.ts
+++ b/src/persistence/deserialization/deserialization-manager.ts
@@ -13,12 +13,12 @@ export class DeserializationManager {
   public constructor(private readonly logger: Logger) {}
 
   /**
-   * Adds a new deserialier to the lookup path for deserialization
+   * Adds a new deserialier to the lookup path for deserialization with highest priority
    */
   public registerDeserializer<TSerialized extends JsonPrimitive = JsonPrimitive, TDeserialized = unknown>(
     deserializer: Deserializer<TSerialized, TDeserialized>
   ): void {
-    this.deserializers.push(deserializer as Deserializer);
+    this.deserializers.unshift(deserializer as Deserializer);
   }
 
   /**


### PR DESCRIPTION
## Description
Reverse the deserialization priority, so the most recently registered deserializers have priority. Previously, priority was given to the earliest registered. This switch makes it easier to add custom deserializers after bootstrap, as the built in ones already cover all data types and would intercept any json value before it got to a late registration.


### Testing
Updated unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
