### PR TITLE
feat: expose deserializer type to allow custom deserializers

### DIFF
--- a/src/hyperdash.ts
+++ b/src/hyperdash.ts
@@ -33,6 +33,7 @@ export * from './model/registration/model-registration';
 export * from './persistence/deserialization/collection/array-deserializer';
 export * from './persistence/deserialization/collection/object-deserializer';
 export * from './persistence/deserialization/deserialization-manager';
+export { Deserializer } from './persistence/deserialization/deserializer';
 export * from './persistence/deserialization/model/model-deserializer';
 export * from './persistence/deserialization/primitive/primitive-deserializer';
 export * from './persistence/deserialization/variable/variable-deserializer';


### PR DESCRIPTION
## Description
Expose the deserializer type to allow registration of custom deserializers via the already public api.

### Testing
N/A

### Checklist:
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
