### PR TITLE
ci: update ci

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -53,6 +55,7 @@ jobs:
 
       - name: Publish Unit Test Results
         uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
+        continue-on-error: true
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: test-results/**/*.xml

--- a/.snyk
+++ b/.snyk
@@ -1,9 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.14.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore:
-  SNYK-JS-LODASH-567746:
-    - '*':
-        reason: no fix or usages of vulnerable method
-        expires: 2020-09-30T00:00:00.000Z
+ignore: {}
 patch: {}


### PR DESCRIPTION
## Description
Dependabot now has a read only token and fails to upload test results - so making that optional. Also adding more fetch depth for test to help out codecov branch detection, and removing an old snyk ignore that's expired.
