### PR TITLE
fix: update publishing to correct registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@hypertrace:registry https://hypertrace.jfrog.io/artifactory/npm

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "url": "git@github.com:hypertrace/hyperdash.git"
   },
   "publishConfig": {
-    "registry": "https://hypertrace.jfrog.io/artifactory/npm"
+    "registry": "https://hypertrace.jfrog.io/artifactory/api/npm/npm/"
   },
   "release": {
     "branches": [


### PR DESCRIPTION
## Description

Transition to jfrog used the incorrect url (see https://www.jfrog.com/confluence/display/JFROG/npm+Registry#npmRegistry-UsingthenpmCommandLine )