### PR TITLE
feat: add way to get all instance of a type of model from dashboard

### DIFF
--- a/src/dashboard/dashboard-manager.test.ts
+++ b/src/dashboard/dashboard-manager.test.ts
@@ -175,4 +175,19 @@ describe('Dashboard manager', () => {
     expect(mockModelManager.destroy).toHaveBeenCalledWith(mockOriginalDataSource);
     expect(mockDataSourceManager.setRootDataSource).toHaveBeenCalledWith(mockNewDataSource, dashboard.root);
   });
+
+  test('can retrieve model instances', () => {
+    const dashboard = dashboardManager.create({
+      type: 'serialized-model'
+    });
+
+    const mockDataSource = class MockDataSource {
+      public readonly value: number = Math.random();
+    };
+
+    mockModelManager.getModelInstances = jest.fn().mockReturnValue([new mockDataSource()]);
+
+    expect(dashboard.getModelInstances(mockDataSource).length).toBe(1);
+    expect(mockModelManager.getModelInstances).toHaveBeenCalledWith(mockDataSource);
+  });
 });

--- a/src/dashboard/dashboard.ts
+++ b/src/dashboard/dashboard.ts
@@ -23,7 +23,7 @@ export interface Dashboard<TRoot extends object = object> {
   setTimeRange(timeRange: TimeRange): this;
 
   /**
-   * Returns a serialized from of this dashboard. Note this does not
+   * Returns a serialized form of this dashboard. Note this does not
    * affect the dashboard in any way, it must be explicitly destroyed
    * if it is no longer in use.
    */
@@ -56,4 +56,10 @@ export interface Dashboard<TRoot extends object = object> {
    */
   // tslint:disable-next-line: no-any
   getRootDataSource<T extends DataSource<any>>(): T | undefined;
+
+  /**
+   * Returns a shallow copy array of model instances within a dashboard that match the
+   * argument model class
+   */
+  getModelInstances<T extends object>(modelClass: Constructable<T>): object[];
 }

--- a/src/dashboard/default-dashboard.ts
+++ b/src/dashboard/default-dashboard.ts
@@ -86,4 +86,11 @@ export class DefaultDashboard<TRoot extends object> implements Dashboard<TRoot> 
   public getRootDataSource<T extends DataSource<any>>(): T | undefined {
     return this.dataSourceManager.getRootDataSource(this.root) as T | undefined;
   }
+
+  /**
+   * @inheritdoc
+   */
+  public getModelInstances<T extends object>(modelClass: Constructable<T>): object[] {
+    return this.modelManager.getModelInstances<T>(modelClass);
+  }
 }

--- a/src/model/manager/model-manager.test.ts
+++ b/src/model/manager/model-manager.test.ts
@@ -14,6 +14,14 @@ describe('Model manager', () => {
     // Value used to disambiguate equality between instances
     public readonly value: number = Math.random();
   };
+  const testClass1 = class TestClass1 {
+    // Value used to disambiguate equality between instances
+    public readonly value: number = Math.random();
+  };
+  const testClass2 = class TestClass2 {
+    // Value used to disambiguate equality between instances
+    public readonly value: number = Math.random();
+  };
   let manager: ModelManager;
   let mockLogger: PartialObjectMock<Logger>;
   let mockApiBuilder: PartialObjectMock<ModelApiBuilder<ModelApi>>;
@@ -57,6 +65,15 @@ describe('Model manager', () => {
     );
 
     manager.registerModelApiBuilder(mockApiBuilder as ModelApiBuilder<ModelApi>);
+  });
+
+  test('returns array of instances matching arg', () => {
+    manager.construct(testClass);
+    manager.construct(testClass);
+    manager.construct(testClass1);
+    expect(manager.getModelInstances(testClass).length).toBe(2);
+    expect(manager.getModelInstances(testClass1).length).toBe(1);
+    expect(manager.getModelInstances(testClass2).length).toBe(0);
   });
 
   test('allows constructing new models', () => {

--- a/src/model/manager/model-manager.ts
+++ b/src/model/manager/model-manager.ts
@@ -13,7 +13,7 @@ import { ModelOnDestroy, ModelOnInit } from './model-lifecycle-hooks';
  * models.
  */
 export class ModelManager {
-  private readonly modelInstanceMap: WeakMap<object, ModelInstanceData> = new WeakMap();
+  private readonly modelInstanceMap: Map<object, ModelInstanceData> = new Map();
   private readonly apiBuilders: ModelApiBuilder<ModelApi>[] = [];
   private readonly decorators: ModelDecorator[] = [];
 
@@ -23,6 +23,13 @@ export class ModelManager {
     private readonly modelDestroyedEvent: ModelDestroyedEvent,
     private readonly beforeModelDestroyedEvent: BeforeModelDestroyedEvent
   ) {}
+
+  /**
+   * Returns a shallow copy array of model instances that match the argument model class
+   */
+  public getModelInstances<T extends object>(modelClass: Constructable<T>): object[] {
+    return Array.from(this.modelInstanceMap.keys()).filter(modelInstance => modelInstance instanceof modelClass);
+  }
 
   /**
    * Constructs (@see `ModelManager.construct`) then initializes (@see `ModelManager.initialize`) it
@@ -250,7 +257,8 @@ export class ModelManager {
   }
 }
 
-interface ModelInstanceData {
+// tslint:disable-next-line:completed-docs
+export interface ModelInstanceData {
   /**
    * Parent of tracked model
    */


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
